### PR TITLE
Fix crash under LTO

### DIFF
--- a/src/ipa/raspberrypi/cam_helper.cpp
+++ b/src/ipa/raspberrypi/cam_helper.cpp
@@ -25,7 +25,11 @@ namespace libcamera {
 LOG_DECLARE_CATEGORY(IPARPI)
 }
 
-static std::map<std::string, CamHelperCreateFunc> camHelpers;
+static std::map<std::string, CamHelperCreateFunc>& camHelpers() {
+	static std::map<std::string, CamHelperCreateFunc>* obj =
+		new std::map<std::string, CamHelperCreateFunc>();
+	return *obj;
+}
 
 CamHelper *CamHelper::create(std::string const &camName)
 {
@@ -33,7 +37,7 @@ CamHelper *CamHelper::create(std::string const &camName)
 	 * CamHelpers get registered by static RegisterCamHelper
 	 * initialisers.
 	 */
-	for (auto &p : camHelpers) {
+	for (auto &p : camHelpers()) {
 		if (camName.find(p.first) != std::string::npos)
 			return p.second();
 	}
@@ -253,5 +257,5 @@ void CamHelper::populateMetadata([[maybe_unused]] const MdParser::RegisterMap &r
 RegisterCamHelper::RegisterCamHelper(char const *camName,
 				     CamHelperCreateFunc createFunc)
 {
-	camHelpers[std::string(camName)] = createFunc;
+	camHelpers()[std::string(camName)] = createFunc;
 }

--- a/src/ipa/raspberrypi/controller/algorithm.cpp
+++ b/src/ipa/raspberrypi/controller/algorithm.cpp
@@ -34,14 +34,19 @@ void Algorithm::process([[maybe_unused]] StatisticsPtr &stats,
 
 /* For registering algorithms with the system: */
 
-static std::map<std::string, AlgoCreateFunc> algorithms;
+static std::map<std::string, AlgoCreateFunc>& algorithms() {
+	static std::map<std::string, AlgoCreateFunc>* obj =
+		new std::map<std::string, AlgoCreateFunc>();
+	return *obj;
+}
+
 std::map<std::string, AlgoCreateFunc> const &RPiController::getAlgorithms()
 {
-	return algorithms;
+	return algorithms();
 }
 
 RegisterAlgorithm::RegisterAlgorithm(char const *name,
 				     AlgoCreateFunc createFunc)
 {
-	algorithms[std::string(name)] = createFunc;
+	algorithms()[std::string(name)] = createFunc;
 }


### PR DESCRIPTION
When compiled with LTO (the default on Ubuntu), the global static objects camHelpers and algorithms cause a crash in raspberrypi_ipa_proxy at runtime as they're not allocated by the time the registration routines execute.

This is a fairly crude fix which just converts the global static objects into local static objects inside an equivalently named function.