### PR TITLE
Fix statistics from the Front End for the first few camera frames

### DIFF
--- a/src/ipa/rpi/controller/awb_algorithm.h
+++ b/src/ipa/rpi/controller/awb_algorithm.h
@@ -16,6 +16,7 @@ public:
 	AwbAlgorithm(Controller *controller) : Algorithm(controller) {}
 	/* An AWB algorithm must provide the following: */
 	virtual unsigned int getConvergenceFrames() const = 0;
+	virtual void initialValues(double &gainR, double &gainB) = 0;
 	virtual void setMode(std::string const &modeName) = 0;
 	virtual void setManualGains(double manualR, double manualB) = 0;
 	virtual void enableAuto() = 0;

--- a/src/ipa/rpi/controller/black_level_algorithm.h
+++ b/src/ipa/rpi/controller/black_level_algorithm.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2023, Raspberry Pi Ltd
+ *
+ * black_level_algorithm.h - black level control algorithm interface
+ */
+#pragma once
+
+#include "algorithm.h"
+
+namespace RPiController {
+
+class BlackLevelAlgorithm : public Algorithm
+{
+public:
+	BlackLevelAlgorithm(Controller *controller)
+		: Algorithm(controller) {}
+	/* A black level algorithm must provide the following: */
+	virtual void initialValues(uint16_t &blackLevelR, uint16_t &blackLevelG,
+				   uint16_t &blackLevelB) = 0;
+};
+
+} /* namespace RPiController */

--- a/src/ipa/rpi/controller/rpi/awb.cpp
+++ b/src/ipa/rpi/controller/rpi/awb.cpp
@@ -220,6 +220,12 @@ void Awb::initialise()
 	asyncResults_ = syncResults_;
 }
 
+void Awb::initialValues(double &gainR, double &gainB)
+{
+	gainR = syncResults_.gainR;
+	gainB = syncResults_.gainB;
+}
+
 void Awb::disableAuto()
 {
 	/* Freeze the most recent values, and treat them as manual gains */

--- a/src/ipa/rpi/controller/rpi/awb.h
+++ b/src/ipa/rpi/controller/rpi/awb.h
@@ -95,6 +95,7 @@ public:
 	void initialise() override;
 	int read(const libcamera::YamlObject &params) override;
 	unsigned int getConvergenceFrames() const override;
+	void initialValues(double &gainR, double &gainB) override;
 	void setMode(std::string const &name) override;
 	void setManualGains(double manualR, double manualB) override;
 	void enableAuto() override;

--- a/src/ipa/rpi/controller/rpi/black_level.cpp
+++ b/src/ipa/rpi/controller/rpi/black_level.cpp
@@ -22,7 +22,7 @@ LOG_DEFINE_CATEGORY(RPiBlackLevel)
 #define NAME "rpi.black_level"
 
 BlackLevel::BlackLevel(Controller *controller)
-	: Algorithm(controller)
+	: BlackLevelAlgorithm(controller)
 {
 }
 
@@ -43,6 +43,14 @@ int BlackLevel::read(const libcamera::YamlObject &params)
 		<< " green " << blackLevelG_
 		<< " blue " << blackLevelB_;
 	return 0;
+}
+
+void BlackLevel::initialValues(uint16_t &blackLevelR, uint16_t &blackLevelG,
+			       uint16_t &blackLevelB)
+{
+	blackLevelR = blackLevelR_;
+	blackLevelG = blackLevelG_;
+	blackLevelB = blackLevelB_;
 }
 
 void BlackLevel::prepare(Metadata *imageMetadata)

--- a/src/ipa/rpi/controller/rpi/black_level.h
+++ b/src/ipa/rpi/controller/rpi/black_level.h
@@ -6,19 +6,21 @@
  */
 #pragma once
 
-#include "../algorithm.h"
+#include "../black_level_algorithm.h"
 #include "../black_level_status.h"
 
 /* This is our implementation of the "black level algorithm". */
 
 namespace RPiController {
 
-class BlackLevel : public Algorithm
+class BlackLevel : public BlackLevelAlgorithm
 {
 public:
 	BlackLevel(Controller *controller);
 	char const *name() const override;
 	int read(const libcamera::YamlObject &params) override;
+	void initialValues(uint16_t &blackLevelR, uint16_t &blackLevelG,
+			   uint16_t &blackLevelB) override;
 	void prepare(Metadata *imageMetadata) override;
 
 private:


### PR DESCRIPTION
Get better colour gain and black level values for programming up the FE before the camera has started.

This fixes the stats for the first couple of frames which were otherwise generating bad values and causing initial AGC wobble.