### PR TITLE
New digital gain handling

### DIFF
--- a/src/ipa/rpi/common/ipa_base.cpp
+++ b/src/ipa/rpi/common/ipa_base.cpp
@@ -758,7 +758,7 @@ void IpaBase::applyControls(const ControlList &controls)
 				break;
 			}
 
-			agc->setFixedAnalogueGain(0, ctrl.second.get<float>());
+			agc->setFixedGain(0, ctrl.second.get<float>());
 
 			libcameraMetadata_.set(controls::AnalogueGain,
 					       ctrl.second.get<float>());

--- a/src/ipa/rpi/common/ipa_base.cpp
+++ b/src/ipa/rpi/common/ipa_base.cpp
@@ -285,20 +285,23 @@ void IpaBase::start(const ControlList &controls, StartResult *result)
 	frameLengths_.clear();
 	frameLengths_.resize(FrameLengthsQueueSize, 0s);
 
-	/* SwitchMode may supply updated exposure/gain values to use. */
-	AgcStatus agcStatus;
-	agcStatus.shutterTime = 0.0s;
-	agcStatus.analogueGain = 0.0;
+	/*
+	 * SwitchMode may supply updated exposure/gain values to use.
+	 * agcStatus_ will store these values for us to use until delayed_status values
+	 * start to appear.
+	 */
+	agcStatus_.shutterTime = 0.0s;
+	agcStatus_.analogueGain = 0.0;
 
-	metadata.get("agc.status", agcStatus);
-	if (agcStatus.shutterTime && agcStatus.analogueGain) {
+	metadata.get("agc.status", agcStatus_);
+	if (agcStatus_.shutterTime && agcStatus_.analogueGain) {
 		ControlList ctrls(sensorCtrls_);
-		applyAGC(&agcStatus, ctrls);
+		applyAGC(&agcStatus_, ctrls);
 		result->controls = std::move(ctrls);
 		setCameraTimeoutValue();
 	}
 	/* Make a note of this as it tells us the HDR status of the first few frames. */
-	hdrStatus_ = agcStatus.hdr;
+	hdrStatus_ = agcStatus_.hdr;
 
 	/*
 	 * Initialise frame counts, and decide how many frames must be hidden or
@@ -451,7 +454,9 @@ void IpaBase::prepareIsp(const PrepareParams &params)
 		controller_.prepare(&rpiMetadata);
 		/* Actually prepare the ISP parameters for the frame. */
 		platformPrepareIsp(params, rpiMetadata);
-	}
+		platformPrepareAgc(rpiMetadata);
+	} else
+		platformPrepareAgc(rpiMetadata);
 
 	frameCount_++;
 
@@ -489,6 +494,7 @@ void IpaBase::processStats(const ProcessParams &params)
 	if (rpiMetadata.get("agc.status", agcStatus) == 0) {
 		ControlList ctrls(sensorCtrls_);
 		applyAGC(&agcStatus, ctrls);
+		rpiMetadata.set("agc.status", agcStatus);
 		setDelayedControls.emit(ctrls, ipaContext);
 		setCameraTimeoutValue();
 	}
@@ -1276,8 +1282,14 @@ void IpaBase::reportMetadata(unsigned int ipaContext)
 	AgcPrepareStatus *agcPrepareStatus = rpiMetadata.getLocked<AgcPrepareStatus>("agc.prepare_status");
 	if (agcPrepareStatus) {
 		libcameraMetadata_.set(controls::AeLocked, agcPrepareStatus->locked);
-		libcameraMetadata_.set(controls::DigitalGain, agcPrepareStatus->digitalGain);
 	}
+
+	const AgcStatus *agcStatus = rpiMetadata.getLocked<AgcStatus>("agc.delayed_status");
+	if (agcStatus)
+		libcameraMetadata_.set(controls::DigitalGain, agcStatus->digitalGain);
+	else
+		libcameraMetadata_.set(controls::DigitalGain, agcStatus_.digitalGain);
+	/* The HDR metadata reporting will use this agcStatus too. */
 
 	LuxStatus *luxStatus = rpiMetadata.getLocked<LuxStatus>("lux.status");
 	if (luxStatus)
@@ -1368,7 +1380,6 @@ void IpaBase::reportMetadata(unsigned int ipaContext)
 	 * delayed_status to be available, we use the HDR status that came out of the
 	 * switchMode call.
 	 */
-	const AgcStatus *agcStatus = rpiMetadata.getLocked<AgcStatus>("agc.delayed_status");
 	const HdrStatus &hdrStatus = agcStatus ? agcStatus->hdr : hdrStatus_;
 	if (!hdrStatus.mode.empty() && hdrStatus.mode != "Off") {
 		int32_t hdrMode = controls::HdrModeOff;
@@ -1425,7 +1436,7 @@ void IpaBase::applyFrameDurations(Duration minFrameDuration, Duration maxFrameDu
 	agc->setMaxShutter(maxShutter);
 }
 
-void IpaBase::applyAGC(const struct AgcStatus *agcStatus, ControlList &ctrls)
+void IpaBase::applyAGC(struct AgcStatus *agcStatus, ControlList &ctrls)
 {
 	const int32_t minGainCode = helper_->gainCode(mode_.minAnalogueGain);
 	const int32_t maxGainCode = helper_->gainCode(mode_.maxAnalogueGain);
@@ -1453,6 +1464,19 @@ void IpaBase::applyAGC(const struct AgcStatus *agcStatus, ControlList &ctrls)
 	ctrls.set(V4L2_CID_VBLANK, static_cast<int32_t>(vblank));
 	ctrls.set(V4L2_CID_EXPOSURE, exposureLines);
 	ctrls.set(V4L2_CID_ANALOGUE_GAIN, gainCode);
+
+	/*
+	 * We must update the digital gain to make up for any quantisation that happens, and
+	 * communicate that back into the metadata so that it will appear as the "delayed" status.
+	 * (Note that "exposure" is already the "actual" exposure.)
+	 */
+	double actualGain = helper_->gain(gainCode);
+	double ratio = agcStatus->analogueGain / actualGain;
+	ratio *= agcStatus->shutterTime / exposure;
+	double newDigitalGain = agcStatus->digitalGain * ratio;
+	agcStatus->digitalGain = newDigitalGain;
+	agcStatus->analogueGain = actualGain;
+	agcStatus->shutterTime = exposure;
 
 	/*
 	 * At present, there is no way of knowing if a control is read-only.

--- a/src/ipa/rpi/common/ipa_base.h
+++ b/src/ipa/rpi/common/ipa_base.h
@@ -73,6 +73,7 @@ private:
 
 	virtual void platformPrepareIsp(const PrepareParams &params,
 					RPiController::Metadata &rpiMetadata) = 0;
+	virtual void platformPrepareAgc(RPiController::Metadata &rpiMetadata) = 0;
 	virtual RPiController::StatisticsPtr platformProcessStats(Span<uint8_t> mem) = 0;
 
 	void setMode(const IPACameraSensorInfo &sensorInfo);
@@ -84,7 +85,7 @@ private:
 	void fillDeviceStatus(const ControlList &sensorControls, unsigned int ipaContext);
 	void reportMetadata(unsigned int ipaContext);
 	void applyFrameDurations(utils::Duration minFrameDuration, utils::Duration maxFrameDuration);
-	void applyAGC(const struct AgcStatus *agcStatus, ControlList &ctrls);
+	void applyAGC(struct AgcStatus *agcStatus, ControlList &ctrls);
 
 	std::map<unsigned int, MappedFrameBuffer> buffers_;
 
@@ -125,6 +126,9 @@ private:
 protected:
 	/* Remember the HDR status after a mode switch. */
 	HdrStatus hdrStatus_;
+
+	/* Remember the AGC status after a mode switch. */
+	AgcStatus agcStatus_;
 
 	/* Whether the stitch block (if available) needs to swap buffers. */
 	bool stitchSwapBuffers_;

--- a/src/ipa/rpi/controller/agc_algorithm.h
+++ b/src/ipa/rpi/controller/agc_algorithm.h
@@ -26,7 +26,7 @@ public:
 	virtual void setFixedShutter(unsigned int channel,
 				     libcamera::utils::Duration fixedShutter) = 0;
 	virtual void setMaxShutter(libcamera::utils::Duration maxShutter) = 0;
-	virtual void setFixedAnalogueGain(unsigned int channel, double fixedAnalogueGain) = 0;
+	virtual void setFixedGain(unsigned int channel, double fixedGain) = 0;
 	virtual void setMeteringMode(std::string const &meteringModeName) = 0;
 	virtual void setExposureMode(std::string const &exposureModeName) = 0;
 	virtual void setConstraintMode(std::string const &contraintModeName) = 0;

--- a/src/ipa/rpi/controller/agc_status.h
+++ b/src/ipa/rpi/controller/agc_status.h
@@ -37,7 +37,7 @@ struct AgcStatus {
 	libcamera::utils::Duration flickerPeriod;
 	int floatingRegionEnable;
 	libcamera::utils::Duration fixedShutter;
-	double fixedAnalogueGain;
+	double fixedGain;
 	unsigned int channel;
 	HdrStatus hdr;
 };

--- a/src/ipa/rpi/controller/agc_status.h
+++ b/src/ipa/rpi/controller/agc_status.h
@@ -44,6 +44,5 @@ struct AgcStatus {
 };
 
 struct AgcPrepareStatus {
-	double digitalGain;
 	int locked;
 };

--- a/src/ipa/rpi/controller/agc_status.h
+++ b/src/ipa/rpi/controller/agc_status.h
@@ -30,6 +30,7 @@ struct AgcStatus {
 	libcamera::utils::Duration targetExposureValue; /* (unfiltered) target total exposure AGC is aiming for */
 	libcamera::utils::Duration shutterTime;
 	double analogueGain;
+	double digitalGain;
 	std::string exposureMode;
 	std::string constraintMode;
 	std::string meteringMode;

--- a/src/ipa/rpi/controller/rpi/agc.cpp
+++ b/src/ipa/rpi/controller/rpi/agc.cpp
@@ -144,14 +144,14 @@ void Agc::setFixedShutter(unsigned int channelIndex, Duration fixedShutter)
 	channelData_[channelIndex].channel.setFixedShutter(fixedShutter);
 }
 
-void Agc::setFixedAnalogueGain(unsigned int channelIndex, double fixedAnalogueGain)
+void Agc::setFixedGain(unsigned int channelIndex, double fixedGain)
 {
 	if (checkChannel(channelIndex))
 		return;
 
-	LOG(RPiAgc, Debug) << "setFixedAnalogueGain " << fixedAnalogueGain
+	LOG(RPiAgc, Debug) << "setFixedGain " << fixedGain
 			   << " for channel " << channelIndex;
-	channelData_[channelIndex].channel.setFixedAnalogueGain(fixedAnalogueGain);
+	channelData_[channelIndex].channel.setFixedGain(fixedGain);
 }
 
 void Agc::setMeteringMode(std::string const &meteringModeName)

--- a/src/ipa/rpi/controller/rpi/agc.h
+++ b/src/ipa/rpi/controller/rpi/agc.h
@@ -35,8 +35,8 @@ public:
 	void setMaxShutter(libcamera::utils::Duration maxShutter) override;
 	void setFixedShutter(unsigned int channelIndex,
 			     libcamera::utils::Duration fixedShutter) override;
-	void setFixedAnalogueGain(unsigned int channelIndex,
-				  double fixedAnalogueGain) override;
+	void setFixedGain(unsigned int channelIndex,
+			  double fixedGain) override;
 	void setMeteringMode(std::string const &meteringModeName) override;
 	void setExposureMode(std::string const &exposureModeName) override;
 	void setConstraintMode(std::string const &contraintModeName) override;

--- a/src/ipa/rpi/controller/rpi/agc_channel.cpp
+++ b/src/ipa/rpi/controller/rpi/agc_channel.cpp
@@ -412,14 +412,9 @@ void AgcChannel::switchMode(CameraMode const &cameraMode,
 
 	Duration fixedShutter = limitShutter(fixedShutter_);
 	if (fixedShutter && fixedAnalogueGain_) {
-		/* We're going to reset the algorithm here with these fixed values. */
-		fetchAwbStatus(metadata);
-		double minColourGain = std::min({ awb_.gainR, awb_.gainG, awb_.gainB, 1.0 });
-		ASSERT(minColourGain != 0.0);
-
 		/* This is the equivalent of computeTargetExposure and applyDigitalGain. */
 		target_.totalExposureNoDG = fixedShutter_ * fixedAnalogueGain_;
-		target_.totalExposure = target_.totalExposureNoDG / minColourGain;
+		target_.totalExposure = target_.totalExposureNoDG;
 
 		/* Equivalent of filterExposure. This resets any "history". */
 		filtered_ = target_;
@@ -439,10 +434,10 @@ void AgcChannel::switchMode(CameraMode const &cameraMode,
 		 */
 
 		double ratio = lastSensitivity / cameraMode.sensitivity;
-		target_.totalExposureNoDG *= ratio;
 		target_.totalExposure *= ratio;
-		filtered_.totalExposureNoDG *= ratio;
+		target_.totalExposureNoDG = target_.totalExposure;
 		filtered_.totalExposure *= ratio;
+		filtered_.totalExposureNoDG = filtered_.totalExposure;
 
 		divideUpExposure();
 	} else {
@@ -693,9 +688,17 @@ static double computeInitialY(StatisticsPtr &stats, AwbStatus const &awb,
 	double ySum;
 	/* Factor in the AWB correction if needed. */
 	if (stats->agcStatsPos == Statistics::AgcStatsPos::PreWb) {
-		ySum = rSum * awb.gainR * .299 +
-		       gSum * awb.gainG * .587 +
-		       bSum * awb.gainB * .114;
+		/*
+		 * We apply any extra gain that will automatically be added by the pipeline
+		 * on account of low colour gains. This means that this statistic should then
+		 * drive the exposure to the correct point. The hard-coded 0.1 here doesn't
+		 * really mean anything, just stops arithmetic errors and extreme behaviour.
+		 */
+		double minColourGain = std::min({ awb.gainR, awb.gainG, awb.gainB, 1.0 });
+		double extraGain = 1.0 / std::max({ minColourGain, 0.1 });
+		ySum = rSum * awb.gainR * extraGain * .299 +
+		       gSum * awb.gainG * extraGain * .587 +
+		       bSum * awb.gainB * extraGain * .114;
 	} else
 		ySum = rSum * .299 + gSum * .587 + bSum * .114;
 
@@ -775,16 +778,8 @@ void AgcChannel::computeGain(StatisticsPtr &statistics, Metadata *imageMetadata,
 void AgcChannel::computeTargetExposure(double gain)
 {
 	if (status_.fixedShutter && status_.fixedAnalogueGain) {
-		/*
-		 * When ag and shutter are both fixed, we need to drive the
-		 * total exposure so that we end up with a digital gain of at least
-		 * 1/minColourGain. Otherwise we'd desaturate channels causing
-		 * white to go cyan or magenta.
-		 */
-		double minColourGain = std::min({ awb_.gainR, awb_.gainG, awb_.gainB, 1.0 });
-		ASSERT(minColourGain != 0.0);
 		target_.totalExposure =
-			status_.fixedShutter * status_.fixedAnalogueGain / minColourGain;
+			status_.fixedShutter * status_.fixedAnalogueGain;
 	} else {
 		/*
 		 * The statistics reflect the image without digital gain, so the final
@@ -845,15 +840,8 @@ bool AgcChannel::applyChannelConstraints(const AgcChannelTotalExposures &channel
 
 bool AgcChannel::applyDigitalGain(double gain, double targetY, bool channelBound)
 {
-	double minColourGain = std::min({ awb_.gainR, awb_.gainG, awb_.gainB, 1.0 });
-	ASSERT(minColourGain != 0.0);
-	double dg = 1.0 / minColourGain;
-	/*
-	 * I think this pipeline subtracts black level and rescales before we
-	 * get the stats, so no need to worry about it.
-	 */
-	LOG(RPiAgc, Debug) << "after AWB, target dg " << dg << " gain " << gain
-			   << " target_Y " << targetY;
+	double dg = 1.0;
+
 	/*
 	 * Finally, if we're trying to reduce exposure but the target_Y is
 	 * "close" to 1.0, then the gain computed for that constraint will be

--- a/src/ipa/rpi/controller/rpi/agc_channel.cpp
+++ b/src/ipa/rpi/controller/rpi/agc_channel.cpp
@@ -454,25 +454,9 @@ void AgcChannel::prepare(Metadata *imageMetadata)
 	AgcPrepareStatus prepareStatus;
 
 	prepareStatus.locked = false;
-	prepareStatus.digitalGain = 1.0;
 
-	if (!imageMetadata->get("device.status", deviceStatus)) {
+	if (!imageMetadata->get("device.status", deviceStatus))
 		prepareStatus.locked = updateLockStatus(deviceStatus);
-
-		/*
-		 * For now, the IPA code is still expecting the digital gain to combe back in
-		 * the prepare_status. To keep things happy, we'll just fill in the value that
-		 * we calculated previously and put in the AgcStatus (which comes back as the
-		 * "delayed" status). Once the rest of the IPA code is updated, we'll be able
-		 * to remove this, and indeed remove the digitalGain from the AgcPrepareStatus.
-		 */
-		AgcStatus delayedStatus;
-		if (!imageMetadata->get("agc.delayed_status", delayedStatus))
-			prepareStatus.digitalGain = delayedStatus.digitalGain;
-		else
-			/* After a mode switch, this must be correct until new values come through. */
-			prepareStatus.digitalGain = status_.digitalGain;
-	}
 
 	imageMetadata->set("agc.prepare_status", prepareStatus);
 }

--- a/src/ipa/rpi/controller/rpi/agc_channel.cpp
+++ b/src/ipa/rpi/controller/rpi/agc_channel.cpp
@@ -261,7 +261,7 @@ int AgcConfig::read(const libcamera::YamlObject &params)
 }
 
 AgcChannel::ExposureValues::ExposureValues()
-	: shutter(0s), analogueGain(0),
+	: shutter(0s), analogueGain(0), digitalGain(0),
 	  totalExposure(0s), totalExposureNoDG(0s)
 {
 }
@@ -409,17 +409,10 @@ void AgcChannel::switchMode(CameraMode const &cameraMode,
 	mode_ = cameraMode;
 
 	Duration fixedShutter = limitShutter(fixedShutter_);
+	double fixedGain = limitGain(fixedGain_);
 	if (fixedShutter_ && fixedGain_) {
-		/* This is the equivalent of computeTargetExposure and applyDigitalGain. */
-		target_.totalExposureNoDG = fixedShutter_ * fixedGain_;
-		target_.totalExposure = target_.totalExposureNoDG;
-
-		/* Equivalent of filterExposure. This resets any "history". */
-		filtered_ = target_;
-
-		/* Equivalent of divideUpExposure. */
-		filtered_.shutter = fixedShutter;
-		filtered_.analogueGain = fixedGain_;
+		filtered_.totalExposureNoDG = fixedShutter * fixedGain;
+		filtered_.totalExposure = filtered_.totalExposureNoDG;
 	} else if (status_.totalExposureValue) {
 		/*
 		 * On a mode switch, various things could happen:
@@ -432,12 +425,8 @@ void AgcChannel::switchMode(CameraMode const &cameraMode,
 		 */
 
 		double ratio = lastSensitivity / cameraMode.sensitivity;
-		target_.totalExposure *= ratio;
-		target_.totalExposureNoDG = target_.totalExposure;
 		filtered_.totalExposure *= ratio;
 		filtered_.totalExposureNoDG = filtered_.totalExposure;
-
-		divideUpExposure();
 	} else {
 		/*
 		 * We come through here on startup, when at least one of the shutter
@@ -446,55 +435,46 @@ void AgcChannel::switchMode(CameraMode const &cameraMode,
 		 * for any that weren't set.
 		 */
 
-		/* Equivalent of divideUpExposure. */
-		filtered_.shutter = fixedShutter ? fixedShutter : config_.defaultExposureTime;
-		filtered_.analogueGain = fixedGain_ ? fixedGain_ : config_.defaultAnalogueGain;
+		Duration shutter = fixedShutter ? fixedShutter : config_.defaultExposureTime;
+		double gain = fixedGain ? fixedGain : config_.defaultAnalogueGain;
+		filtered_.totalExposure = shutter * gain;
+		filtered_.totalExposureNoDG = filtered_.totalExposure;
 	}
+
+	/* Setting target_ to filtered_ removes any history from before the mode switch. */
+	target_ = filtered_;
+	divideUpExposure();
 
 	writeAndFinish(metadata, false);
 }
 
 void AgcChannel::prepare(Metadata *imageMetadata)
 {
-	Duration totalExposureValue = status_.totalExposureValue;
-	AgcStatus delayedStatus;
+	DeviceStatus deviceStatus;
 	AgcPrepareStatus prepareStatus;
 
-	/* Fetch the AWB status now because AWB also sets it in the prepare method. */
-	fetchAwbStatus(imageMetadata);
-
-	if (!imageMetadata->get("agc.delayed_status", delayedStatus))
-		totalExposureValue = delayedStatus.totalExposureValue;
-
-	prepareStatus.digitalGain = 1.0;
 	prepareStatus.locked = false;
+	prepareStatus.digitalGain = 1.0;
 
-	if (status_.totalExposureValue) {
-		/* Process has run, so we have meaningful values. */
-		DeviceStatus deviceStatus;
-		if (imageMetadata->get("device.status", deviceStatus) == 0) {
-			Duration actualExposure = deviceStatus.shutterSpeed *
-						  deviceStatus.analogueGain;
-			if (actualExposure) {
-				double digitalGain = totalExposureValue / actualExposure;
-				LOG(RPiAgc, Debug) << "Want total exposure " << totalExposureValue;
-				/*
-				 * Never ask for a gain < 1.0, and also impose
-				 * some upper limit. Make it customisable?
-				 */
-				prepareStatus.digitalGain = std::max(1.0, std::min(digitalGain,
-										   config_.maxDigitalGain));
-				LOG(RPiAgc, Debug) << "Actual exposure " << actualExposure;
-				LOG(RPiAgc, Debug) << "Use digitalGain " << prepareStatus.digitalGain;
-				LOG(RPiAgc, Debug) << "Effective exposure "
-						   << actualExposure * prepareStatus.digitalGain;
-				/* Decide whether AEC/AGC has converged. */
-				prepareStatus.locked = updateLockStatus(deviceStatus);
-			}
-		} else
-			LOG(RPiAgc, Warning) << "AgcChannel: no device metadata";
-		imageMetadata->set("agc.prepare_status", prepareStatus);
+	if (!imageMetadata->get("device.status", deviceStatus)) {
+		prepareStatus.locked = updateLockStatus(deviceStatus);
+
+		/*
+		 * For now, the IPA code is still expecting the digital gain to combe back in
+		 * the prepare_status. To keep things happy, we'll just fill in the value that
+		 * we calculated previously and put in the AgcStatus (which comes back as the
+		 * "delayed" status). Once the rest of the IPA code is updated, we'll be able
+		 * to remove this, and indeed remove the digitalGain from the AgcPrepareStatus.
+		 */
+		AgcStatus delayedStatus;
+		if (!imageMetadata->get("agc.delayed_status", delayedStatus))
+			prepareStatus.digitalGain = delayedStatus.digitalGain;
+		else
+			/* After a mode switch, this must be correct until new values come through. */
+			prepareStatus.digitalGain = status_.digitalGain;
 	}
+
+	imageMetadata->set("agc.prepare_status", prepareStatus);
 }
 
 void AgcChannel::process(StatisticsPtr &stats, DeviceStatus const &deviceStatus,
@@ -580,7 +560,7 @@ void AgcChannel::housekeepConfig()
 	/* First fetch all the up-to-date settings, so no one else has to do it. */
 	status_.ev = ev_;
 	status_.fixedShutter = limitShutter(fixedShutter_);
-	status_.fixedGain = fixedGain_;
+	status_.fixedGain = limitGain(fixedGain_);
 	status_.flickerPeriod = flickerPeriod_;
 	LOG(RPiAgc, Debug) << "ev " << status_.ev << " fixedShutter "
 			   << status_.fixedShutter << " fixedGain "
@@ -631,6 +611,9 @@ void AgcChannel::fetchCurrentExposure(DeviceStatus const &deviceStatus)
 	current_.analogueGain = deviceStatus.analogueGain;
 	current_.totalExposure = 0s; /* this value is unused */
 	current_.totalExposureNoDG = current_.shutter * current_.analogueGain;
+	LOG(RPiAgc, Debug) << "Current frame: shutter " << current_.shutter
+			   << " ag " << current_.analogueGain
+			   << " (total " << current_.totalExposureNoDG << ")";
 }
 
 void AgcChannel::fetchAwbStatus(Metadata *imageMetadata)
@@ -790,11 +773,9 @@ void AgcChannel::computeTargetExposure(double gain)
 					      ? status_.fixedShutter
 					      : exposureMode_->shutter.back();
 		maxShutter = limitShutter(maxShutter);
-		Duration maxTotalExposure =
-			maxShutter *
-			(status_.fixedGain != 0.0
-				 ? status_.fixedGain
-				 : exposureMode_->gain.back());
+		double maxGain = status_.fixedGain ? status_.fixedGain : exposureMode_->gain.back();
+		maxGain = limitGain(maxGain);
+		Duration maxTotalExposure = maxShutter * maxGain;
 		target_.totalExposure = std::min(target_.totalExposure, maxTotalExposure);
 	}
 	LOG(RPiAgc, Debug) << "Target totalExposure " << target_.totalExposure;
@@ -803,8 +784,6 @@ void AgcChannel::computeTargetExposure(double gain)
 bool AgcChannel::applyChannelConstraints(const AgcChannelTotalExposures &channelTotalExposures)
 {
 	bool channelBound = false;
-	LOG(RPiAgc, Debug)
-		<< "Total exposure before channel constraints " << filtered_.totalExposure;
 
 	for (const auto &constraint : config_.channelConstraints) {
 		LOG(RPiAgc, Debug)
@@ -839,7 +818,7 @@ bool AgcChannel::applyChannelConstraints(const AgcChannelTotalExposures &channel
 
 bool AgcChannel::applyDigitalGain(double gain, double targetY, bool channelBound)
 {
-	double dg = 1.0;
+	filtered_.totalExposureNoDG = filtered_.totalExposure;
 
 	/*
 	 * Finally, if we're trying to reduce exposure but the target_Y is
@@ -850,15 +829,14 @@ bool AgcChannel::applyDigitalGain(double gain, double targetY, bool channelBound
 	 * quickly (and we then approach the correct value more quickly from
 	 * below).
 	 */
-	bool desaturate = false;
-	if (config_.desaturate)
-		desaturate = !channelBound &&
-			     targetY > config_.fastReduceThreshold && gain < sqrt(targetY);
-	if (desaturate)
-		dg /= config_.fastReduceThreshold;
-	LOG(RPiAgc, Debug) << "Digital gain " << dg << " desaturate? " << desaturate;
-	filtered_.totalExposureNoDG = filtered_.totalExposure / dg;
-	LOG(RPiAgc, Debug) << "Target totalExposureNoDG " << filtered_.totalExposureNoDG;
+	bool desaturate = config_.desaturate && !channelBound &&
+			  targetY > config_.fastReduceThreshold && gain < sqrt(targetY);
+
+	if (desaturate) {
+		filtered_.totalExposureNoDG *= config_.fastReduceThreshold;
+		LOG(RPiAgc, Debug) << "Desaturating, exposure no dg " << filtered_.totalExposureNoDG;
+	}
+
 	return desaturate;
 }
 
@@ -890,8 +868,7 @@ void AgcChannel::filterExposure()
 		filtered_.totalExposure = speed * target_.totalExposure +
 					  filtered_.totalExposure * (1.0 - speed);
 	}
-	LOG(RPiAgc, Debug) << "After filtering, totalExposure " << filtered_.totalExposure
-			   << " no dg " << filtered_.totalExposureNoDG;
+	LOG(RPiAgc, Debug) << "After filtering, totalExposure " << filtered_.totalExposure;
 }
 
 void AgcChannel::divideUpExposure()
@@ -932,10 +909,9 @@ void AgcChannel::divideUpExposure()
 			}
 		}
 	}
-	LOG(RPiAgc, Debug) << "Divided up shutter and gain are " << shutterTime << " and "
-			   << gain;
+
 	/*
-	 * Finally adjust shutter time for flicker avoidance (require both
+	 * Adjust shutter time for flicker avoidance (require both
 	 * shutter and gain not to be fixed).
 	 */
 	if (!status_.fixedShutter && !status_.fixedGain &&
@@ -944,22 +920,29 @@ void AgcChannel::divideUpExposure()
 		if (flickerPeriods) {
 			Duration newShutterTime = flickerPeriods * status_.flickerPeriod;
 			gain *= shutterTime / newShutterTime;
-			/*
-			 * We should still not allow the ag to go over the
-			 * largest value in the exposure mode. Note that this
-			 * may force more of the total exposure into the digital
-			 * gain as a side-effect.
-			 */
-			gain = std::min(gain, exposureMode_->gain.back());
-			gain = limitGain(gain);
 			shutterTime = newShutterTime;
 		}
 		LOG(RPiAgc, Debug) << "After flicker avoidance, shutter "
 				   << shutterTime << " gain " << gain;
 	}
+
+	/*
+	 * Now limit the analogue gain to the maximum allowed, so that we can figure
+	 * out how much digital gain we need.
+	 */
+	double digitalGain = 1.0;
+	if (gain > mode_.maxAnalogueGain) {
+		digitalGain = gain / mode_.maxAnalogueGain;
+		gain = mode_.maxAnalogueGain;
+	}
+
+	filtered_.totalExposureNoDG = gain * shutterTime;
+	filtered_.totalExposure = filtered_.totalExposureNoDG * digitalGain;
 	filtered_.shutter = shutterTime;
-	/* We ask for all the gain as analogue gain; prepare() will be told what we got. */
 	filtered_.analogueGain = gain;
+	filtered_.digitalGain = digitalGain;
+	LOG(RPiAgc, Debug) << "DivideUpExposure: " << shutterTime << " ag " << gain
+			   << " dg " << digitalGain;
 }
 
 void AgcChannel::writeAndFinish(Metadata *imageMetadata, bool desaturate)
@@ -968,6 +951,7 @@ void AgcChannel::writeAndFinish(Metadata *imageMetadata, bool desaturate)
 	status_.targetExposureValue = desaturate ? 0s : target_.totalExposure;
 	status_.shutterTime = filtered_.shutter;
 	status_.analogueGain = filtered_.analogueGain;
+	status_.digitalGain = filtered_.digitalGain;
 	/*
 	 * Write to metadata as well, in case anyone wants to update the camera
 	 * immediately.
@@ -975,8 +959,6 @@ void AgcChannel::writeAndFinish(Metadata *imageMetadata, bool desaturate)
 	imageMetadata->set("agc.status", status_);
 	LOG(RPiAgc, Debug) << "Output written, total exposure requested is "
 			   << filtered_.totalExposure;
-	LOG(RPiAgc, Debug) << "Camera exposure update: shutter time " << filtered_.shutter
-			   << " analogue gain " << filtered_.analogueGain;
 }
 
 Duration AgcChannel::limitShutter(Duration shutter)
@@ -1005,6 +987,7 @@ double AgcChannel::limitGain(double gain) const
 	if (!gain)
 		return gain;
 
-	gain = std::max(gain, mode_.minAnalogueGain);
+	gain = std::clamp(gain, mode_.minAnalogueGain,
+			  mode_.maxAnalogueGain * config_.maxDigitalGain);
 	return gain;
 }

--- a/src/ipa/rpi/controller/rpi/agc_channel.cpp
+++ b/src/ipa/rpi/controller/rpi/agc_channel.cpp
@@ -255,6 +255,8 @@ int AgcConfig::read(const libcamera::YamlObject &params)
 
 	desaturate = params["desaturate"].get<int>(1);
 
+	maxDigitalGain = params["max_digital_gain"].get<double>(4.0);
+
 	return 0;
 }
 
@@ -484,7 +486,8 @@ void AgcChannel::prepare(Metadata *imageMetadata)
 				 * Never ask for a gain < 1.0, and also impose
 				 * some upper limit. Make it customisable?
 				 */
-				prepareStatus.digitalGain = std::max(1.0, std::min(digitalGain, 4.0));
+				prepareStatus.digitalGain = std::max(1.0, std::min(digitalGain,
+										   config_.maxDigitalGain));
 				LOG(RPiAgc, Debug) << "Actual exposure " << actualExposure;
 				LOG(RPiAgc, Debug) << "Use digitalGain " << prepareStatus.digitalGain;
 				LOG(RPiAgc, Debug) << "Effective exposure "

--- a/src/ipa/rpi/controller/rpi/agc_channel.h
+++ b/src/ipa/rpi/controller/rpi/agc_channel.h
@@ -130,6 +130,7 @@ private:
 
 		libcamera::utils::Duration shutter;
 		double analogueGain;
+		double digitalGain;
 		libcamera::utils::Duration totalExposure;
 		libcamera::utils::Duration totalExposureNoDG; /* without digital gain */
 	};

--- a/src/ipa/rpi/controller/rpi/agc_channel.h
+++ b/src/ipa/rpi/controller/rpi/agc_channel.h
@@ -77,6 +77,7 @@ struct AgcConfig {
 	double defaultAnalogueGain;
 	double stableRegion;
 	bool desaturate;
+	double maxDigitalGain;
 };
 
 class AgcChannel

--- a/src/ipa/rpi/controller/rpi/agc_channel.h
+++ b/src/ipa/rpi/controller/rpi/agc_channel.h
@@ -92,7 +92,7 @@ public:
 	void setFlickerPeriod(libcamera::utils::Duration flickerPeriod);
 	void setMaxShutter(libcamera::utils::Duration maxShutter);
 	void setFixedShutter(libcamera::utils::Duration fixedShutter);
-	void setFixedAnalogueGain(double fixedAnalogueGain);
+	void setFixedGain(double fixedGain);
 	void setMeteringMode(std::string const &meteringModeName);
 	void setExposureMode(std::string const &exposureModeName);
 	void setConstraintMode(std::string const &contraintModeName);
@@ -148,7 +148,7 @@ private:
 	libcamera::utils::Duration flickerPeriod_;
 	libcamera::utils::Duration maxShutter_;
 	libcamera::utils::Duration fixedShutter_;
-	double fixedAnalogueGain_;
+	double fixedGain_;
 };
 
 } /* namespace RPiController */

--- a/src/ipa/rpi/pisp/pisp.cpp
+++ b/src/ipa/rpi/pisp/pisp.cpp
@@ -523,10 +523,24 @@ void IpaPiSP::applyWBG(const AwbStatus *awbStatus, const AgcPrepareStatus *agcPr
 	pisp_wbg_config wbg;
 	pisp_fe_rgby_config rgby = {};
 	double dg = agcPrepareStatus ? agcPrepareStatus->digitalGain : 1.0;
+	double minColourGain = std::min({ awbStatus->gainR, awbStatus->gainG, awbStatus->gainB, 1.0 });
+	/* The 0.1 here doesn't mean much, but just stops arithmetic errors and extreme behaviour. */
+	double extraGain = 1.0 / std::max({ minColourGain, 0.1 });
 
-	wbg.gain_r = clampField(dg * awbStatus->gainR, 14, 10);
-	wbg.gain_g = clampField(dg * awbStatus->gainG, 14, 10);
-	wbg.gain_b = clampField(dg * awbStatus->gainB, 14, 10);
+	/*
+	 * Apply an extra gain of 1 / minColourGain so as not to apply < 1 gains to any
+	 * channels (which would cause saturated pixels to go cyan or magenta).
+	 * Doing this doesn't really apply more gain than necessary, because one of the
+	 * channels is always getting the minimum gain possible. For this reason we also
+	 * don't change the values that we report externally.
+	 */
+	double gainR = awbStatus->gainR * extraGain;
+	double gainG = awbStatus->gainG * extraGain;
+	double gainB = awbStatus->gainB * extraGain;
+
+	wbg.gain_r = clampField(dg * gainR, 14, 10);
+	wbg.gain_g = clampField(dg * gainG, 14, 10);
+	wbg.gain_b = clampField(dg * gainB, 14, 10);
 
 	/*
 	 * The YCbCr conversion block should contain the appropriate YCbCr
@@ -537,9 +551,9 @@ void IpaPiSP::applyWBG(const AwbStatus *awbStatus, const AgcPrepareStatus *agcPr
 	be_->GetYcbcr(csc);
 
 	/* The CSC coefficients already have the << 10 scaling applied. */
-	rgby.gain_r = clampField(csc.coeffs[0] * awbStatus->gainR, 14);
-	rgby.gain_g = clampField(csc.coeffs[1] * awbStatus->gainG, 14);
-	rgby.gain_b = clampField(csc.coeffs[2] * awbStatus->gainB, 14);
+	rgby.gain_r = clampField(csc.coeffs[0] * gainR, 14);
+	rgby.gain_g = clampField(csc.coeffs[1] * gainG, 14);
+	rgby.gain_b = clampField(csc.coeffs[2] * gainB, 14);
 
 	LOG(IPARPI, Debug) << "Applying WB R: " << awbStatus->gainR << " B: "
 			   << awbStatus->gainB;

--- a/src/ipa/rpi/vc4/vc4.cpp
+++ b/src/ipa/rpi/vc4/vc4.cpp
@@ -57,6 +57,7 @@ private:
 	int32_t platformConfigure(const ConfigParams &params, ConfigResult *result) override;
 
 	void platformPrepareIsp(const PrepareParams &params, RPiController::Metadata &rpiMetadata) override;
+	void platformPrepareAgc([[maybe_unused]] RPiController::Metadata &rpiMetadata) override {}
 	RPiController::StatisticsPtr platformProcessStats(Span<uint8_t> mem) override;
 
 	void handleControls(const ControlList &controls) override;

--- a/src/ipa/rpi/vc4/vc4.cpp
+++ b/src/ipa/rpi/vc4/vc4.cpp
@@ -57,15 +57,14 @@ private:
 	int32_t platformConfigure(const ConfigParams &params, ConfigResult *result) override;
 
 	void platformPrepareIsp(const PrepareParams &params, RPiController::Metadata &rpiMetadata) override;
-	void platformPrepareAgc([[maybe_unused]] RPiController::Metadata &rpiMetadata) override {}
+	void platformPrepareAgc([[maybe_unused]] RPiController::Metadata &rpiMetadata) override;
 	RPiController::StatisticsPtr platformProcessStats(Span<uint8_t> mem) override;
 
 	void handleControls(const ControlList &controls) override;
 	bool validateIspControls();
 
 	void applyAWB(const struct AwbStatus *awbStatus, ControlList &ctrls);
-	void applyDG(const struct AgcPrepareStatus *dgStatus,
-		     const struct AwbStatus *awbStatus, ControlList &ctrls);
+	void applyDG(double digitalGain, const struct AwbStatus *awbStatus, ControlList &ctrls);
 	void applyCCM(const struct CcmStatus *ccmStatus, ControlList &ctrls);
 	void applyBlackLevel(const struct BlackLevelStatus *blackLevelStatus, ControlList &ctrls);
 	void applyGamma(const struct ContrastStatus *contrastStatus, ControlList &ctrls);
@@ -79,6 +78,7 @@ private:
 
 	/* VC4 ISP controls. */
 	ControlInfoMap ispCtrls_;
+	ControlList ctrls_;
 
 	/* LS table allocation passed in from the pipeline handler. */
 	SharedFD lsTableHandle_;
@@ -108,6 +108,7 @@ int32_t IpaVc4::platformStart([[maybe_unused]] const ControlList &controls,
 int32_t IpaVc4::platformConfigure(const ConfigParams &params, [[maybe_unused]] ConfigResult *result)
 {
 	ispCtrls_ = params.ispControls;
+	ctrls_ = ControlList(ispCtrls_);
 	if (!validateIspControls()) {
 		LOG(IPARPI, Error) << "ISP control validation failed.";
 		return -1;
@@ -140,7 +141,7 @@ int32_t IpaVc4::platformConfigure(const ConfigParams &params, [[maybe_unused]] C
 void IpaVc4::platformPrepareIsp([[maybe_unused]] const PrepareParams &params,
 				RPiController::Metadata &rpiMetadata)
 {
-	ControlList ctrls(ispCtrls_);
+	ControlList &ctrls = ctrls_;
 
 	/* Lock the metadata buffer to avoid constant locks/unlocks. */
 	std::unique_lock<RPiController::Metadata> lock(rpiMetadata);
@@ -152,9 +153,6 @@ void IpaVc4::platformPrepareIsp([[maybe_unused]] const PrepareParams &params,
 	CcmStatus *ccmStatus = rpiMetadata.getLocked<CcmStatus>("ccm.status");
 	if (ccmStatus)
 		applyCCM(ccmStatus, ctrls);
-
-	AgcPrepareStatus *dgStatus = rpiMetadata.getLocked<AgcPrepareStatus>("agc.prepare_status");
-	applyDG(dgStatus, awbStatus, ctrls);
 
 	AlscStatus *lsStatus = rpiMetadata.getLocked<AlscStatus>("alsc.status");
 	if (lsStatus)
@@ -191,9 +189,18 @@ void IpaVc4::platformPrepareIsp([[maybe_unused]] const PrepareParams &params,
 		if (!lensctrls.empty())
 			setLensControls.emit(lensctrls);
 	}
+}
 
-	if (!ctrls.empty())
-		setIspControls.emit(ctrls);
+void IpaVc4::platformPrepareAgc(RPiController::Metadata &rpiMetadata)
+{
+	AgcStatus *delayedAgcStatus = rpiMetadata.getLocked<AgcStatus>("agc.delayed_status");
+	double digitalGain = delayedAgcStatus ? delayedAgcStatus->digitalGain : agcStatus_.digitalGain;
+	AwbStatus *awbStatus = rpiMetadata.getLocked<AwbStatus>("awb.status");
+
+	applyDG(digitalGain, awbStatus, ctrls_);
+
+	setIspControls.emit(ctrls_);
+	ctrls_ = ControlList(ispCtrls_);
 }
 
 RPiController::StatisticsPtr IpaVc4::platformProcessStats(Span<uint8_t> mem)
@@ -329,11 +336,9 @@ void IpaVc4::applyAWB(const struct AwbStatus *awbStatus, ControlList &ctrls)
 		  static_cast<int32_t>(awbStatus->gainB * 1000));
 }
 
-void IpaVc4::applyDG(const struct AgcPrepareStatus *dgStatus,
+void IpaVc4::applyDG(double digitalGain,
 		     const struct AwbStatus *awbStatus, ControlList &ctrls)
 {
-	double digitalGain = dgStatus ? dgStatus->digitalGain : 1.0;
-
 	if (awbStatus) {
 		/*
 		 * We must apply sufficient extra digital gain to stop any of the channel gains being


### PR DESCRIPTION
This certainly isn't ready for merging yet, but it might be worth starting to have a look at it.

The digital gain calculation is moved out of prepare() and into process().

The IPA classes are updated to fetch the digital gain from the delayed status, so we can no longer have the problem where prepare() gets skipped (at higher framerates) causing the image to "wink" with an old digital gain value.

There are still some things to think about.

For instance, the updating of the "actual" exposure/gain values when we write them to the sensor means we have to write them back to the metadata so that the correctly adjusted digital gain will be in the delayed status.

The split of platformPrepareIsp into platformPrepareIsp and platformPrepareAgc (the latter always being called, even when platformPrepareIsp is skipped), and probably other things too.