### PR TITLE
RASPBERRYPI ONLY: Use meson from pip when generating orig tarball

### DIFF
--- a/.github/workflows/gen_orig.yml
+++ b/.github/workflows/gen_orig.yml
@@ -14,8 +14,9 @@ jobs:
       - name: Install dependencies
         run: | # Local cmake needs to be removed for pybind11 to be detected
           sudo rm -rf /usr/local/bin/cmake
+          pip3 install --user meson
           sudo apt-get update
-          sudo apt-get install -y meson pkgconf cmake libgtest-dev libyaml-dev python3 python3-dev pybind11-dev python3-jinja2 python3-ply python3-yaml
+          sudo apt-get install -y ninja-build pkgconf cmake libgtest-dev libyaml-dev python3 python3-dev pybind11-dev python3-jinja2 python3-ply python3-yaml
       - name: Check out repository code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Looks like the a newer version of meson is required now. Could you please re-tag with this change?