### PR TITLE
ipa: rpi: Add imx290.json to meson.build.

### DIFF
--- a/src/ipa/rpi/pisp/data/meson.build
+++ b/src/ipa/rpi/pisp/data/meson.build
@@ -3,6 +3,7 @@
 conf_files = files([
     'imx219.json',
     'imx219_noir.json',
+    'imx290.json',
     'imx296.json',
     'imx296_mono.json',
     'imx378.json',


### PR DESCRIPTION
The file imx290.json was present in the tree, but wasn't included in meson.build and so was never installed.

Add it in so that imx290/327/462 all work on Pi5.