### PR TITLE
support imx500 to run more output tensors

### DIFF
--- a/src/ipa/rpi/controller/controller.h
+++ b/src/ipa/rpi/controller/controller.h
@@ -31,7 +31,7 @@ namespace RPiController {
  * Applications must cast the span to these structures exactly.
  */
 static constexpr unsigned int NetworkNameLen = 64;
-static constexpr unsigned int MaxNumTensors = 8;
+static constexpr unsigned int MaxNumTensors = 16;
 static constexpr unsigned int MaxNumDimensions = 8;
 
 struct OutputTensorInfo {

--- a/src/libcamera/control_ids_rpi.yaml
+++ b/src/libcamera/control_ids_rpi.yaml
@@ -82,7 +82,7 @@ controls:
         takes the following form:
 
         constexpr unsigned int NetworkNameLen = 64;
-        constexpr unsigned int MaxNumTensors = 8;
+        constexpr unsigned int MaxNumTensors = 16;
         constexpr unsigned int MaxNumDimensions = 8;
 
         struct CnnOutputTensorInfo {


### PR DESCRIPTION
Updated the magic number to 16, as MAX_NUM_TENSORS=8 is too limited for multi-task networks.