### PR TITLE
Ctt fixes

### DIFF
--- a/utils/raspberrypi/ctt/ctt.py
+++ b/utils/raspberrypi/ctt/ctt.py
@@ -198,9 +198,12 @@ class Camera:
         """
         Write output to json
         """
-        self.json['rpi.cac']['cac'] = cacs
-        self.log += '\nCAC calibration written to json file'
-        print('Finished CAC calibration')
+        if cacs:
+            self.json['rpi.cac']['cac'] = cacs
+            self.log += '\nCAC calibration written to json file'
+            print('Finished CAC calibration')
+        else:
+            self.log += "\nCAC calibration failed"
 
 
     """

--- a/utils/raspberrypi/ctt/ctt_alsc.py
+++ b/utils/raspberrypi/ctt/ctt_alsc.py
@@ -127,11 +127,12 @@ def alsc(Cam, Img, do_alsc_colour, plot=False, grid_size=(16, 12), max_gain=8.0)
     channels = [Img.channels[i] for i in Img.order]
     """
     calculate size of single rectangle.
-    -(-(w-1)//32) is a ceiling division. w-1 is to deal robustly with the case
-    where w is a multiple of 32.
+    The divisions here must ensure the final row/column of cells has a non-zero number of
+    pixels.
     """
     w, h = Img.w/2, Img.h/2
-    dx, dy = int(-(-(w-1)//grid_w)), int(-(-(h-1)//grid_h))
+    dx, dy = (w - 1) // (grid_w - 1), (h - 1) // (grid_h - 1)
+
     """
     average the green channels into one
     """


### PR DESCRIPTION
This fixes a couple of calculation issues in the ctt.

The first is a bug in the lens shading calibration measurement, which is now fixed.

The second occurs during CAC calibration, if not enough parts of the image have dots in them. In this case it will print a message and disable CAC.