### PR TITLE
pipeline: rpi: Add comments (only) to vc4 YAML defaults files.

### DIFF
--- a/src/libcamera/pipeline/rpi/vc4/data/example.yaml
+++ b/src/libcamera/pipeline/rpi/vc4/data/example.yaml
@@ -37,5 +37,18 @@
                 # timeout value.
                 #
                 # "camera_timeout_value_ms": 0,
+
+                # Override any request from the IPA to drop a number of startup
+                # frames.
+                #
+                # "disable_startup_frame_drops": false,
+
+                # Set if the application will always provide a request buffer
+                # for the RAW stream, if it has been configured.
+                # "raw_mandatory_stream": false,
+
+                # Set if application will always provide a request buffer
+                # for the Output 0 stream, if it has been configured.
+                # "output0_mandatory_stream": false,
         }
 }

--- a/src/libcamera/pipeline/rpi/vc4/data/rpi_apps.yaml
+++ b/src/libcamera/pipeline/rpi/vc4/data/rpi_apps.yaml
@@ -29,6 +29,15 @@
                 #
                 "min_total_unicam_buffers": 4,
 
+                # Custom timeout value (in ms) for camera to use. This overrides
+                # the value computed by the pipeline handler based on frame
+                # durations.
+                #
+                # Set this value to 0 to use the pipeline handler computed
+                # timeout value.
+                #
+                # "camera_timeout_value_ms": 0,
+
                 # Override any request from the IPA to drop a number of startup
                 # frames.
                 #


### PR DESCRIPTION
example.yaml: Add comments about "disable_startup_frame_drops", "raw_mandatory_stream" and "output0_mandatory_stream" options.

rpi_apps.yaml: Add a comment about "camera_timeout_value_ms" although it is not changed from the default value (following the existing example of "disable_startup_frame_drops").