### PR TITLE
ipa: rpi: sync: Convert wallclock from nanoseconds to microseconds

### DIFF
--- a/src/ipa/rpi/controller/rpi/sync.cpp
+++ b/src/ipa/rpi/controller/rpi/sync.cpp
@@ -163,8 +163,8 @@ void Sync::process([[maybe_unused]] StatisticsPtr &stats, Metadata *imageMetadat
 
 	imageMetadata->get("sync.params", local);
 
-	/* The wallclock has already been de-jittered for us. */
-	uint64_t wallClockFrameTimestamp = local.wallClock;
+	/* The wallclock has already been de-jittered for us. Convert from ns into us. */
+	uint64_t wallClockFrameTimestamp = local.wallClock / 1000;
 
 	/*
 	 * This is the headline frame duration in microseconds as programmed into the sensor. Strictly,


### PR DESCRIPTION
The wallclock timestamp has been changed to nanosecond units, and all the calculations here assume it's in microseconds, so add the necessary conversion.

Fixes: 29a88d85b730 ("libcamera: controls: Use nanoseconds units for FrameWallClock")