### PR TITLE
ipa: rpi: Expose frameCount in extracted IMX500 tensors

### DIFF
--- a/src/ipa/rpi/cam_helper/cam_helper_imx500.cpp
+++ b/src/ipa/rpi/cam_helper/cam_helper_imx500.cpp
@@ -245,6 +245,7 @@ void CamHelperImx500::parseInferenceData(libcamera::Span<const uint8_t> buffer,
 				exported.width = inputTensorInfo.width;
 				exported.height = inputTensorInfo.height;
 				exported.numChannels = inputTensorInfo.channels;
+				exported.frameCount = inputTensorInfo.frameCount;
 				strncpy(exported.networkName, inputTensorInfo.networkName.c_str(),
 					sizeof(exported.networkName) - 1);
 				exported.networkName[sizeof(exported.networkName) - 1] = '\0';
@@ -281,6 +282,7 @@ void CamHelperImx500::parseInferenceData(libcamera::Span<const uint8_t> buffer,
 			strncpy(exported.networkName, outputTensorInfo.networkName.c_str(),
 				sizeof(exported.networkName) - 1);
 			exported.networkName[sizeof(exported.networkName) - 1] = '\0';
+			exported.frameCount = outputTensorInfo.frameCount;
 			metadata.set("cnn.output_tensor_info", exported);
 			metadata.set("cnn.output_tensor", std::move(outputTensorInfo.data));
 			metadata.set("cnn.output_tensor_size", outputTensorInfo.totalSize);

--- a/src/ipa/rpi/cam_helper/imx500_tensor_parser/imx500_tensor_parser.cpp
+++ b/src/ipa/rpi/cam_helper/imx500_tensor_parser/imx500_tensor_parser.cpp
@@ -623,6 +623,7 @@ int parseInputTensorBody(IMX500InputTensorInfo &inputTensorInfo, const uint8_t *
 	inputTensorInfo.widthStride = inputApParams.widthStride;
 	inputTensorInfo.heightStride = inputApParams.heightStride;
 	inputTensorInfo.networkName = inputApParams.networkName;
+	inputTensorInfo.frameCount = dnnHeader.frameCount;
 
 	return 0;
 }
@@ -693,6 +694,7 @@ int RPiController::imx500ParseOutputTensor(IMX500OutputTensorInfo &outputTensorI
 		LOG(IMX500, Error) << "Failed to populate OutputTensorInfo!";
 		return ret;
 	}
+	outputTensorInfo.frameCount = dnnHeader.frameCount;
 
 	ret = parseOutputTensorBody(outputTensorInfo, src + TensorStride, outputApParams, dnnHeader);
 	if (ret) {

--- a/src/ipa/rpi/cam_helper/imx500_tensor_parser/imx500_tensor_parser.h
+++ b/src/ipa/rpi/cam_helper/imx500_tensor_parser/imx500_tensor_parser.h
@@ -36,6 +36,7 @@ struct IMX500OutputTensorInfo {
 	std::vector<uint32_t> tensorDataNum;
 	std::vector<std::vector<Dimensions>> vecDim;
 	std::vector<uint32_t> numDimensions;
+	uint8_t frameCount;
 };
 
 struct IMX500InputTensorInfo {
@@ -47,6 +48,7 @@ struct IMX500InputTensorInfo {
 	unsigned int size;
 	std::string networkName;
 	std::shared_ptr<uint8_t[]> data;
+	uint8_t frameCount;
 };
 
 struct IMX500Tensors {

--- a/src/ipa/rpi/controller/controller.h
+++ b/src/ipa/rpi/controller/controller.h
@@ -44,6 +44,7 @@ struct CnnOutputTensorInfo {
 	char networkName[NetworkNameLen];
 	uint32_t numTensors;
 	OutputTensorInfo info[MaxNumTensors];
+	uint8_t frameCount;
 };
 
 struct CnnInputTensorInfo {
@@ -51,6 +52,7 @@ struct CnnInputTensorInfo {
 	uint32_t width;
 	uint32_t height;
 	uint32_t numChannels;
+	uint8_t frameCount;
 };
 
 struct CnnKpiInfo {

--- a/src/libcamera/control_ids_rpi.yaml
+++ b/src/libcamera/control_ids_rpi.yaml
@@ -218,6 +218,7 @@ controls:
           char networkName[NetworkNameLen];
           uint32_t numTensors;
           OutputTensorInfo info[MaxNumTensors];
+          uint8_t frameCount;
         };
 
         with
@@ -279,6 +280,7 @@ controls:
           uint32_t width;
           uint32_t height;
           uint32_t numChannels;
+          uint8_t frameCount;
         };
 
         where


### PR DESCRIPTION
When injecting input tensors, the output results are expected to be made available at a specific frame. This change exports tensors' frameCount so that an appropriate comparison can be made by the controlling application.