### PR TITLE
ipa: rpi: agc: Clamp digital gain to avoid saturation issues

### DIFF
--- a/src/ipa/rpi/controller/rpi/agc_channel.cpp
+++ b/src/ipa/rpi/controller/rpi/agc_channel.cpp
@@ -941,8 +941,8 @@ void AgcChannel::divideUpExposure()
 	/* Finally work out the digital gain that we will need. */
 	filtered_.totalExposureNoDG = analogueGain * exposureTime;
 	double digitalGain = filtered_.totalExposure / filtered_.totalExposureNoDG;
-	/* Limit dg by what is allowed. */
-	digitalGain = std::min(digitalGain, config_.maxDigitalGain);
+	/* Limit dg by what is allowed (and to 1.0 to avoid saturation issues). */
+	digitalGain = std::clamp(digitalGain, 1.0, config_.maxDigitalGain);
 	/* Update total exposure, in case the dg went down. */
 	filtered_.totalExposure = filtered_.totalExposureNoDG * digitalGain;
 


### PR DESCRIPTION
Digital gain is used to adjust overall image exposure when the target exposure cannot be achieved (for example, cannot go high enough). But when the target exposure is lower than we can achieve, the digital gain was being set to values less than unity, causing saturation problems.

The fix is simply to clamp the digital gain at the bottom to 1.0, resulting in images that, while "too bright", saturate correctly.

Fixes: 17f9912cff85 ("ipa: rpi: agc: Calculate digital gain in process()")

Reviewed-by: Alen Karnil <alen.karnil@ideasonboard.com>
Tested-by: Alen Karnil <alen.karnil@ideasonboard.com>
Reviewed-by: Kieran Bingham <kieran.bingham@ideasonboard.com>