### PR TITLE
Add a new OutputWindows control

### DIFF
--- a/src/libcamera/pipeline/rpi/common/rpi_stream.h
+++ b/src/libcamera/pipeline/rpi/common/rpi_stream.h
@@ -97,14 +97,14 @@ public:
 	using StreamFlags = Flags<StreamFlag>;
 
 	Stream()
-		: flags_(StreamFlag::None), id_(0), swDownscale_(0)
+		: flags_(StreamFlag::None), id_(0), swDownscale_(0), ispOutputIndex_(-1)
 	{
 	}
 
 	Stream(const char *name, MediaEntity *dev, StreamFlags flags = StreamFlag::None)
 		: flags_(flags), name_(name),
 		  dev_(std::make_unique<V4L2VideoDevice>(dev)), id_(0),
-		  swDownscale_(0)
+		  swDownscale_(0), ispOutputIndex_(-1)
 	{
 	}
 
@@ -124,6 +124,9 @@ public:
 	unsigned int getBufferId(FrameBuffer *buffer) const;
 
 	void setExportedBuffer(FrameBuffer *buffer);
+
+	void setIspIndex(int ispIndex) { ispOutputIndex_ = ispIndex; }
+	int getIspIndex() const { return ispOutputIndex_; }
 
 	int allocateBuffers(unsigned int count);
 	int queueBuffer(FrameBuffer *buffer);
@@ -181,6 +184,9 @@ private:
 	 * as the stream needs to maintain ownership of these buffers.
 	 */
 	std::vector<std::unique_ptr<FrameBuffer>> internalBuffers_;
+
+	/* For output streams, the ISP branch for this stream (otherwise -1). */
+	int ispOutputIndex_;
 };
 
 /*

--- a/src/libcamera/pipeline/rpi/pisp/pisp.cpp
+++ b/src/libcamera/pipeline/rpi/pisp/pisp.cpp
@@ -1524,6 +1524,7 @@ int PiSPCameraData::platformConfigure(const RPi::RPiCameraConfiguration *rpiConf
 			beEnables |= PISP_BE_RGB_ENABLE_OUTPUT0;
 			ispIndex = 0;
 		}
+		stream->setIspIndex(ispIndex);
 
 		format = outStreams[i].format;
 		bool needs32BitConversion = adjustDeviceFormat(format);
@@ -2305,6 +2306,24 @@ void PiSPCameraData::tryRunPipeline()
 	/* Take the first request from the queue and action the IPA. */
 	Request *request = requestQueue_.front();
 	ASSERT(request->metadata().empty());
+
+	/* Pass the plane offsets of any output buffers to the Back End ISP. */
+	for (auto const &[stream, buffer] : request->buffers()) {
+		int ispIndex = static_cast<const RPi::Stream *>(stream)->getIspIndex();
+		if (ispIndex >= 0) {
+			/*
+			 * PiSP takes only 2 offsets; offset 3 (where required) is assumed
+			 * to be the same as offset 2.
+			 */
+			unsigned int offset = buffer->planes()[0].offset;
+			unsigned int offset2 = 0;
+			if (buffer->planes().size() > 1)
+				offset2 = buffer->planes()[1].offset;
+
+			pisp_be_output_format_extra extra{ 0, 0, { offset, offset2 } };
+			be_->SetOutputFormatExtra(ispIndex, extra);
+		}
+	}
 
 	/* See if a new ScalerCrop value needs to be applied. */
 	applyScalerCrop(request->controls());


### PR DESCRIPTION
This control lets you direct the camera image at only a smaller "window" within the normal output image.

It is intended primarily for ML applications that might want to create a square image but where the camera output is "letterboxed" within it.