### PR TITLE
Expose `contains` in `ControlInfoMap`

### DIFF
--- a/include/libcamera/controls.h
+++ b/include/libcamera/controls.h
@@ -390,6 +390,7 @@ public:
 	using Map::size;
 	using Map::count;
 	using Map::find;
+	using Map::contains;
 
 	mapped_type &at(unsigned int key);
 	const mapped_type &at(unsigned int key) const;


### PR DESCRIPTION
C++ 20 adds `contains` to `std::unordered_map`. Since this project appears to currently be built with C++ 20, this PR exposes the `contains` method in `ControlInfoMap` so that dependent projects may use it. (If supporting prior versions of C++ is necessary, this would need a version check.)